### PR TITLE
v1.0.0 - Basic otel configuration

### DIFF
--- a/config.go
+++ b/config.go
@@ -98,7 +98,6 @@ func (config *OpenTelemetryConfiguration) guardForEmptyServiceName() {
 func NewOpenTelemetryConfiguraion() *OpenTelemetryConfiguration {
 	config := new(OpenTelemetryConfiguration)
 	config.exporterProtocol = GRPC
-	config.collectorURL = default_gRPC_URL()
 	config.serviceVersion = default_version
 	config.autoGenerateInstanceID = true
 	config.insecure = true

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-package golang_otel
+package otel
 
 import (
 	"errors"

--- a/context.go
+++ b/context.go
@@ -1,4 +1,4 @@
-package golang_otel
+package otel
 
 import (
 	"context"

--- a/context.go
+++ b/context.go
@@ -1,0 +1,18 @@
+package golang_otel
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"time"
+)
+
+func CreateSignalContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	return ctx, cancel
+}
+
+func buildTimeoutContext(ctx context.Context, config *OpenTelemetryConfiguration) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(ctx, config.contextTimeout*time.Second)
+	return ctx, cancel
+}

--- a/defaults.go
+++ b/defaults.go
@@ -1,7 +1,5 @@
 package golang_otel
 
-import "fmt"
-
 const default_version = "1.0.0"
 
 const localhost = "127.0.0.1"
@@ -9,11 +7,3 @@ const localhost = "127.0.0.1"
 const gRPC_port = 4317
 
 const http_port = 4318
-
-func default_gRPC_URL() string {
-	return fmt.Sprintf("%s:%d", localhost, gRPC_port)
-}
-
-func default_HTTP_URL() string {
-	return fmt.Sprintf("%s:%d", localhost, http_port)
-}

--- a/defaults.go
+++ b/defaults.go
@@ -1,4 +1,4 @@
-package golang_otel
+package otel
 
 const default_version = "1.0.0"
 

--- a/exporter.go
+++ b/exporter.go
@@ -1,4 +1,4 @@
-package golang_otel
+package otel
 
 import (
 	"context"

--- a/exporter.go
+++ b/exporter.go
@@ -4,44 +4,14 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
-func createExporter(ctx context.Context, config *OpenTelemetryConfiguration) *otlptrace.Exporter {
+func buildTraceExporter(ctx context.Context, config *OpenTelemetryConfiguration) *otlptrace.Exporter {
 	if config.exporterProtocol == HTTP {
-		url := getHTTPexporterURL(config)
-		client := otlptracehttp.NewClient(otlptracehttp.WithEndpoint(url))
-		exporter, err := otlptrace.New(ctx, client)
-		if err != nil {
-			panic(err)
-		}
+		exporter := buildHTTPTraceExporter(ctx, config)
 		return exporter
 	}
-	url := getGRPCexporterURL(config)
-	connection, err := grpc.DialContext(ctx, url, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
-	if err != nil {
-		panic(err)
-	}
-	exporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithGRPCConn(connection))
-	if err != nil {
-		panic(err)
-	}
+
+	exporter := buildGRPCTraceExporter(ctx, config)
 	return exporter
-}
-
-func getHTTPexporterURL(config *OpenTelemetryConfiguration) string {
-	if config.collectorURL == "" {
-		return default_HTTP_URL()
-	}
-	return config.collectorURL
-}
-
-func getGRPCexporterURL(config *OpenTelemetryConfiguration) string {
-	if config.collectorURL == "" {
-		return default_gRPC_URL()
-	}
-	return config.collectorURL
 }

--- a/exporter.go
+++ b/exporter.go
@@ -14,12 +14,21 @@ func createExporter(ctx context.Context, config *OpenTelemetryConfiguration) *ot
 	if config.exporterProtocol == HTTP {
 		url := getHTTPexporterURL(config)
 		client := otlptracehttp.NewClient(otlptracehttp.WithEndpoint(url))
-		exporter, _ := otlptrace.New(ctx, client)
+		exporter, err := otlptrace.New(ctx, client)
+		if err != nil {
+			panic(err)
+		}
 		return exporter
 	}
 	url := getGRPCexporterURL(config)
-	connection, _ := grpc.DialContext(ctx, url, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
-	exporter, _ := otlptracegrpc.New(ctx, otlptracegrpc.WithGRPCConn(connection))
+	connection, err := grpc.DialContext(ctx, url, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	if err != nil {
+		panic(err)
+	}
+	exporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithGRPCConn(connection))
+	if err != nil {
+		panic(err)
+	}
 	return exporter
 }
 

--- a/grpc_exporter.go
+++ b/grpc_exporter.go
@@ -1,4 +1,4 @@
-package golang_otel
+package otel
 
 import (
 	"context"

--- a/grpc_exporter.go
+++ b/grpc_exporter.go
@@ -1,0 +1,44 @@
+package golang_otel
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"google.golang.org/grpc"
+)
+
+func buildGRPCTraceExporter(ctx context.Context, config *OpenTelemetryConfiguration) *otlptrace.Exporter {
+	connection := buildGRPCconnection(ctx, config)
+	exporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithGRPCConn(connection))
+
+	if err != nil {
+		panic(err)
+	}
+
+	return exporter
+}
+
+func buildGRPCconnection(ctx context.Context, config *OpenTelemetryConfiguration) *grpc.ClientConn {
+	url := buildGRPCexporterURL(config.collectorURL)
+	credentials := config.grpcCredentials
+	connection, err := grpc.DialContext(ctx, url, grpc.WithTransportCredentials(credentials), grpc.WithBlock())
+
+	if err != nil {
+		panic(err)
+	}
+
+	return connection
+}
+
+func buildGRPCexporterURL(collectorURL string) string {
+	if collectorURL == "" {
+		return default_gRPC_URL()
+	}
+	return collectorURL
+}
+
+func default_gRPC_URL() string {
+	return fmt.Sprintf("%s:%d", localhost, gRPC_port)
+}

--- a/http_exporter.go
+++ b/http_exporter.go
@@ -1,4 +1,4 @@
-package golang_otel
+package otel
 
 import (
 	"context"

--- a/http_exporter.go
+++ b/http_exporter.go
@@ -1,0 +1,55 @@
+package golang_otel
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+)
+
+func buildHTTPTraceExporter(ctx context.Context, config *OpenTelemetryConfiguration) *otlptrace.Exporter {
+	collectorURL := config.collectorURL
+	insecure := config.insecure
+	client := buildHTTPClient(collectorURL, insecure)
+	exporter, err := otlptrace.New(ctx, client)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return exporter
+}
+
+func buildHTTPClient(collectorURL string, insecure bool) otlptrace.Client {
+
+	options := buildHTTPClientOptions(collectorURL, insecure)
+
+	client := otlptracehttp.NewClient(options...)
+
+	return client
+}
+
+func buildHTTPClientOptions(collectorURL string, insecure bool) []otlptracehttp.Option {
+	options := make([]otlptracehttp.Option, 0)
+	url := buildHTTPexporterURL(collectorURL)
+	options = append(options, otlptracehttp.WithEndpoint(url))
+
+	if insecure {
+		options = append(options, otlptracehttp.WithInsecure())
+	}
+
+	return options
+}
+
+func buildHTTPexporterURL(collectorURL string) string {
+	if collectorURL == "" {
+		return default_HTTP_URL()
+	}
+
+	return collectorURL
+}
+
+func default_HTTP_URL() string {
+	return fmt.Sprintf("%s:%d", localhost, http_port)
+}

--- a/otel.go
+++ b/otel.go
@@ -1,4 +1,4 @@
-package golang_otel
+package otel
 
 import (
 	"context"

--- a/otel.go
+++ b/otel.go
@@ -2,17 +2,12 @@ package golang_otel
 
 import (
 	"context"
-	"os"
-	"os/signal"
-	"time"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 func ConfigureOpenTelemetryTracing(ctx context.Context, configure ConfigureTracing) (func(context.Context) error, error) {
-	config := NewOtelConfiguration()
+	config := NewOpenTelemetryConfiguraion()
 
 	configure(config)
 
@@ -20,26 +15,18 @@ func ConfigureOpenTelemetryTracing(ctx context.Context, configure ConfigureTraci
 
 	resource := buildResource(ctx, config)
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	ctx, cancel := buildTimeoutContext(ctx, config)
 	defer cancel()
 
-	exporter := createExporter(ctx, config)
+	exporter := buildTraceExporter(ctx, config)
 
-	batchSpanProcessor := sdktrace.NewBatchSpanProcessor(exporter)
+	spanProcessor := buildSpanProcessor(config, exporter)
 
-	traceProvider := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		sdktrace.WithResource(resource),
-		sdktrace.WithSpanProcessor(batchSpanProcessor),
-	)
+	tracerProvider := buildTracerProvider(resource, spanProcessor)
 
-	otel.SetTracerProvider(traceProvider)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+	otel.SetTracerProvider(tracerProvider)
 
-	return traceProvider.Shutdown, nil
-}
+	setTextMapPropagator(config)
 
-func CreateSignalContext() (context.Context, context.CancelFunc) {
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
-	return ctx, cancel
+	return tracerProvider.Shutdown, nil
 }

--- a/processor.go
+++ b/processor.go
@@ -1,4 +1,4 @@
-package golang_otel
+package otel
 
 import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"

--- a/processor.go
+++ b/processor.go
@@ -1,0 +1,26 @@
+package golang_otel
+
+import (
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func buildSpanProcessor(config *OpenTelemetryConfiguration, exporter *otlptrace.Exporter) sdktrace.SpanProcessor {
+	if config.spanProcessorType == BATCH {
+		spanProcessor := buildBatchSpanProcessor(exporter)
+		return spanProcessor
+	}
+
+	spanProcessor := buildSimpleSpanProcessor(exporter)
+	return spanProcessor
+}
+
+func buildBatchSpanProcessor(exporter *otlptrace.Exporter) sdktrace.SpanProcessor {
+	batchSpanProcessor := sdktrace.NewBatchSpanProcessor(exporter)
+	return batchSpanProcessor
+}
+
+func buildSimpleSpanProcessor(exporter *otlptrace.Exporter) sdktrace.SpanProcessor {
+	simpleSpanProcessor := sdktrace.NewSimpleSpanProcessor(exporter)
+	return simpleSpanProcessor
+}

--- a/propagators.go
+++ b/propagators.go
@@ -1,4 +1,4 @@
-package golang_otel
+package otel
 
 import (
 	"go.opentelemetry.io/otel"

--- a/propagators.go
+++ b/propagators.go
@@ -1,0 +1,21 @@
+package golang_otel
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+func buildDefaultPropagator() propagation.TextMapPropagator {
+	return propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})
+}
+
+func setTextMapPropagator(config *OpenTelemetryConfiguration) {
+	if config.propagator == nil {
+		propagator := buildDefaultPropagator()
+		otel.SetTextMapPropagator(propagator)
+		return
+	}
+
+	propagator := config.propagator
+	otel.SetTextMapPropagator(*propagator)
+}

--- a/resource.go
+++ b/resource.go
@@ -1,4 +1,4 @@
-package golang_otel
+package otel
 
 import (
 	"context"

--- a/resource.go
+++ b/resource.go
@@ -3,6 +3,7 @@ package golang_otel
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
@@ -53,4 +54,8 @@ func getServiceVersion(version string) string {
 		return default_version
 	}
 	return version
+}
+
+func generateInstanceID() string {
+	return uuid.NewString()
 }

--- a/trace_provider.go
+++ b/trace_provider.go
@@ -1,0 +1,16 @@
+package golang_otel
+
+import (
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func buildTracerProvider(resource *resource.Resource, spanProcessor sdktrace.SpanProcessor) *sdktrace.TracerProvider {
+	tracerProvider := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithResource(resource),
+		sdktrace.WithSpanProcessor(spanProcessor),
+	)
+
+	return tracerProvider
+}

--- a/trace_provider.go
+++ b/trace_provider.go
@@ -1,4 +1,4 @@
-package golang_otel
+package otel
 
 import (
 	"go.opentelemetry.io/otel/sdk/resource"


### PR DESCRIPTION
# Configurations for OTEL trace
- [x] add service metadata configuration (name, namespace, version, instance id)
- [x] add collector URL support
- [x] add insecure connections support for HTTP exporter
- [x] add context timeout support
- [x] add gRPC credentials support
- [x] add exporter protocol support (HTTP/gRPC)
- [x] add span processor type (BATCH/SIMPLE)
- [x] add custom text map propagation support